### PR TITLE
Add base setup for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# scratchpad
+# Scratchpad
+
+This repository will contain a collection of shell and Python scripts.
+
+## Setup
+
+Install Python dependencies with:
+
+```
+pip install -r requirements.txt
+```
+
+Run the initialization script for shell helpers:
+
+```
+./init.sh
+```
+
+

--- a/init.sh
+++ b/init.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
 
-echo "XD"
+# Basic initialization for shell scripts
+
+set -e
+
+# Example environment variable
+export PROJECT_ROOT="$(pwd)"
+
+# Placeholder for additional setup tasks
+
+echo "Shell environment initialized at $PROJECT_ROOT"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Base Python dependencies
+requests
+pandas
+


### PR DESCRIPTION
## Summary
- add base Python dependencies
- add a basic shell setup script
- document setup instructions in the README

## Testing
- `bash -n init.sh`
- `python3 -m compileall .`

------
https://chatgpt.com/codex/tasks/task_e_68433a072f008326a0ae43bfd655483e